### PR TITLE
Do not use pip executable directly when installing dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ debian-deps:
 # Python3 PIP packages
 pip-deps: debian-deps
 	$(info .. Installing system-wide Python3 PIP packages)
-	pip3 install pyelftools \
+	python3 -m pip install pyelftools \
           && printf "import elftools\nprint(elftools)" | python3
 	touch pip-deps
 


### PR DESCRIPTION
In Ubuntu, the pip executable can break on occasion, using the module directly from python [[1]](https://askubuntu.com/a/1065352) is a safer way of installing dependencies. (I just tried installing on an up-to-date Ubuntu 18.04 system, and the `pip3 install pyelftools` command indeed did not work.)