### PR TITLE
Keeping build args as envvars

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,7 @@ jobs:
           core: ${{ matrix.core }}
 
       - name: Build Sancus Security
-        run: cd docker && docker build -t ${{ steps.docker-name.outputs.image-name }} --build-arg SANCUS_BRANCH=master --build-arg SANCUS_SECURITY=${{ matrix.security }} --build-arg SANCUS_KEY=${{ matrix.key }} --build-arg ATOMICITY_MONITOR=${{ matrix.core == 'aion' }} .
+        run: cd docker && docker build -t ${{ steps.docker-name.outputs.image-name }} --build-arg BUILD_BRANCH=master --build-arg BUILD_SECURITY=${{ matrix.security }} --build-arg BUILD_KEY=${{ matrix.key }} --build-arg BUILD_ATOMICITY=${{ matrix.core == 'aion' }} .
 
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,16 +8,20 @@ RUN echo "Europe/Brussels" > /etc/timezone
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -yqq tzdata
 
 # Config parameters
-ARG SANCUS_SECURITY=64
-ARG SANCUS_KEY=deadbeefcafebabe
-ARG SANCUS_BRANCH=master
-ARG ATOMICITY_MONITOR=0
+ARG BUILD_SECURITY=64
+ARG BUILD_KEY=deadbeefcafebabe
+ARG BUILD_BRANCH=master
+ARG BUILD_ATOMICITY=0
+# Set ENV vars based on these arguments
+ENV SANCUS_SECURITY=$BUILD_SECURITY
+ENV SANCUS_KEY=$BUILD_KEY
+ENV SANCUS_BRANCH=$BUILD_BRANCH
+ENV ATOMICITY_MONITOR=$BUILD_ATOMICITY
 WORKDIR sancus
 
 # Build and install latest Sancus toolchain
-RUN git clone --branch $SANCUS_BRANCH https://github.com/sancus-tee/sancus-main.git .
-RUN make install clean \
-	SANCUS_SECURITY=$SANCUS_SECURITY SANCUS_KEY=$SANCUS_KEY ATOMICITY_MONITOR=$ATOMICITY_MONITOR
+RUN git clone --branch $BUILD_BRANCH https://github.com/sancus-tee/sancus-main.git .
+RUN make install clean
 
 # Display a welcome message for interactive sessions
 RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,7 +6,7 @@ SANCUS_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
 all: build run
 
 build:
-	docker build -t $(SANCUS_DOCKER) --build-arg SANCUS_BRANCH=$(SANCUS_BRANCH) --build-arg SANCUS_SECURITY=$(SANCUS_SECURITY) --build-arg SANCUS_KEY=$(SANCUS_KEY) --build-arg ATOMICITY_MONITOR=$(ATOMICITY_MONITOR) .
+	docker build -t $(SANCUS_DOCKER) --build-arg BUILD_BRANCH=$(SANCUS_BRANCH) --build-arg BUILD_SECURITY=$(SANCUS_SECURITY) --build-arg BUILD_KEY=$(SANCUS_KEY) --build-arg BUILD_ATOMICITY=$(ATOMICITY_MONITOR) .
 
 run:
 	docker run -i -t $(SANCUS_DOCKER) /bin/bash


### PR DESCRIPTION
This should fix #11 

I added another layer of `BUILD_` ARG variables so that we can use them to set the `SANCUS_` variables as `ENV`. This required changes in the Dockerfile, Makefile, and actions but should be opaque to the Makefile end-user.